### PR TITLE
Update Galaxy Australia's citation message prompt in the Tool Citatio…

### DIFF
--- a/client/src/components/Citation/Citations.vue
+++ b/client/src/components/Citation/Citations.vue
@@ -16,9 +16,8 @@
                 </b-nav>
             </template>
             <div v-if="source === 'histories'" class="infomessage">
-                When writing up your analysis, remember to include all references that should be cited in order to
-                completely describe your work. Also, please remember to
-                <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
+                Please cite Galaxy Australia (first DOI listed below) in any publication resulting for data you analysed on this service. An example sentence is provided here:<br>
+                We wish to acknowledge Galaxy Australia (as funded by BioCommons, MB, QCIF, AARNET, ARDC, Queensland Government, NCI, Pawsey, Azure) for supporting the analyses shown in this publication.
             </div>
             <div class="citations-formatted">
                 <Citation

--- a/client/src/components/Citation/Citations.vue
+++ b/client/src/components/Citation/Citations.vue
@@ -16,8 +16,10 @@
                 </b-nav>
             </template>
             <div v-if="source === 'histories'" class="infomessage">
-                Please cite Galaxy Australia (first DOI listed below) in any publication resulting for data you analysed on this service. An example sentence is provided here:<br>
-                We wish to acknowledge Galaxy Australia (as funded by BioCommons, MB, QCIF, AARNET, ARDC, Queensland Government, NCI, Pawsey, Azure) for supporting the analyses shown in this publication.
+                Please cite <b>Galaxy Australia</b> (below) in any publication resulting for analysis you performed on this service.<br><br>
+                When acknowledging Galaxy Australia in any publication or presentation, we recommend the following acknowledgement statement:<br><br>
+                “This work was conducted on Galaxy Australia, supported by the Australian BioCommons which is enabled by NCRIS via Bioplatforms Australia funding, the University of Melbourne, QCIF, AARNet, ARDC and the Queensland Government”.<br><br>
+                You are also welcome to use our logo. A variety of logo formats are available for <a href="">download</a>, and the accompanying usage guidelines are <a href="">here</a>.
             </div>
             <div class="citations-formatted">
                 <Citation


### PR DESCRIPTION
Update Galaxy Australia's citation message prompt in the Tool Citations Export page upon Gareth Price's request

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/127712842/225171710-d70a4748-22a7-4a10-b3e1-b531b3bb1d96.png">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open Export Tools Citation page under the History dropdown

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
