### PR TITLE
[25.1] Enforce AAI rules till migration

### DIFF
--- a/client/src/components/Register/RegisterForm.vue
+++ b/client/src/components/Register/RegisterForm.vue
@@ -174,9 +174,10 @@ async function submit() {
 
                                         <BFormText v-localize>
                                             Your public name is an identifier that will be used to generate addresses
-                                            for information you share publicly. Public names must be at least three
-                                            characters in length and contain only lower-case letters, numbers, dots,
-                                            underscores, and dashes ('.', '_', '-').
+                                            for information you share publicly. Public names must start with a
+                                            lower-case letter or number, be between 3 and 128 characters in length, and
+                                            contain only lower-case letters, numbers, underscores, and dashes ('_',
+                                            '-').
                                         </BFormText>
                                     </BFormGroup>
 

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -132,6 +132,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         Create a new user.
         """
+        email = email.lower()
         self._error_on_duplicate_email(email)
         user = self.model_class(email=email)
         if password:
@@ -173,7 +174,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """Get all jobs that are not ready yet and belong to the given user."""
         stmt = select(Job).where(and_(Job.user_id == user.id, Job.state.in_(Job.non_ready_states)))
         jobs = self.session().scalars(stmt)
-        return jobs  # type:ignore[return-value]
+        return jobs  # type: ignore[return-value]
 
     def undelete(self, user, flush=True):
         """Remove the deleted flag for the given user."""

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -36,9 +36,10 @@ VALID_EMAIL_RE = re.compile(r"^[\w.!#$%&'*+\/=?^_`{|}~-]+@[\w](?:[\w-]{0,61}[\w]
 EMAIL_MAX_LEN = 255
 
 # Public name validity parameters
-PUBLICNAME_MAX_LEN = 255
-VALID_PUBLICNAME_RE = re.compile(r"^[a-z0-9._\-]+$")
-VALID_PUBLICNAME_SUB = re.compile(r"[^a-z0-9._\-]")
+PUBLICNAME_MAX_LEN = 128
+PUBLICNAME_MIN_LEN = 3
+VALID_PUBLICNAME_RE = re.compile(r"^[a-z0-9][-a-z0-9_]{2,127}$")
+VALID_PUBLICNAME_SUB = re.compile(r"[^a-z0-9_-]")
 FILL_CHAR = "-"
 
 # Password validity parameters
@@ -71,10 +72,12 @@ def validate_publicname_str(publicname):
     """Validates a string containing a public username."""
     if not publicname:
         return "Public name cannot be empty"
-    if len(publicname) > PUBLICNAME_MAX_LEN:
-        return f"Public name cannot be more than {PUBLICNAME_MAX_LEN} characters in length."
     if not (VALID_PUBLICNAME_RE.match(publicname)):
-        return "Public name must contain only lower-case letters, numbers, '.', '_' and '-'."
+        return (
+            "Public name must start with a lower-case letter or number, be between "
+            f"{PUBLICNAME_MIN_LEN} and {PUBLICNAME_MAX_LEN} characters in length, "
+            "and contain only lower-case letters, numbers, '_' and '-'."
+        )
     return ""
 
 
@@ -164,6 +167,9 @@ def transform_publicname(publicname):
         raise ValueError("Public name cannot be empty")
     publicname = publicname.lower()
     publicname = re.sub(VALID_PUBLICNAME_SUB, FILL_CHAR, publicname)
+    publicname = publicname.lstrip("-_")
+    if len(publicname) < PUBLICNAME_MIN_LEN:
+        publicname = publicname + FILL_CHAR * (PUBLICNAME_MIN_LEN - len(publicname))
     publicname = publicname[:PUBLICNAME_MAX_LEN]
     return publicname
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -847,7 +847,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                         "type": "text",
                         "label": "Public name",
                         "value": username,
-                        "help": 'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, dots, underscores, and dashes (".", "_", "-").',
+                        "help": 'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must start with a lower-case letter or number, be between 3 and 128 characters in length, and contain only lower-case letters, numbers, underscores, and dashes ("_", "-").',
                     }
                 )
             info_form_models = self.get_all_forms(

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -949,6 +949,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             message = validate_email(trans, email, user)
             if message:
                 raise exceptions.RequestParameterInvalidException(message)
+            email = email.lower()
             if user.email != email:
                 # Update user email and user's private role name which must match
                 private_role = trans.app.security_agent.get_private_user_role(user)


### PR DESCRIPTION
This enforces username rules.
Also performs forcible email lowercasing during registration and profile updates.