### PR TITLE
Add rstrip to api_path method in GalaxyAuth0OpenIdConnect

### DIFF
--- a/lib/galaxy/authnz/auth0.py
+++ b/lib/galaxy/authnz/auth0.py
@@ -6,3 +6,6 @@ from galaxy.authnz.oidc import GalaxyOpenIdConnect
 class GalaxyAuth0OpenIdConnect(GalaxyOpenIdConnect, Auth0OpenIdConnectAuth):
     name = "auth0"
     EXTRA_DATA = ["id_token", "refresh_token", ("sub", "id"), "picture", "expires_in"]
+
+    def api_path(self, path=""):
+        return super().api_path(path).rstrip("/")


### PR DESCRIPTION
(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
